### PR TITLE
PT-3386 / PT-3417: Add administration section for configuring the text-mining service

### DIFF
--- a/generic-rest/pom.xml
+++ b/generic-rest/pom.xml
@@ -34,6 +34,21 @@
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-configuration-api</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-configuration-default</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>clinical-text-analysis-extension-api</artifactId>
       <version>${project.version}</version>

--- a/generic-rest/src/main/java/org/phenotips/textanalysis/internal/RESTWrapperConfigurationSource.java
+++ b/generic-rest/src/main/java/org/phenotips/textanalysis/internal/RESTWrapperConfigurationSource.java
@@ -1,0 +1,67 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.textanalysis.internal;
+
+import org.phenotips.Constants;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.internal.AbstractDocumentConfigurationSource;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * @version $Id$
+ */
+@Component
+@Named("textAnnotationServiceConfiguration")
+@Singleton
+public class RESTWrapperConfigurationSource extends AbstractDocumentConfigurationSource
+{
+    private static final LocalDocumentReference CONFIGURATION_CLASS =
+        new LocalDocumentReference(Constants.CODE_SPACE, "TextAnnotationConfigurationClass");
+
+    private static final LocalDocumentReference CONFIGURATION_DOCUMENT =
+        new LocalDocumentReference(Constants.CODE_SPACE, "TextAnnotationConfiguration");
+
+    @Inject
+    private DocumentReferenceResolver<EntityReference> resolver;
+
+    @Override
+    protected DocumentReference getDocumentReference()
+    {
+        return this.resolver.resolve(CONFIGURATION_DOCUMENT);
+    }
+
+    @Override
+    protected LocalDocumentReference getClassReference()
+    {
+        return CONFIGURATION_CLASS;
+    }
+
+    @Override
+    protected String getCacheId()
+    {
+        return "configuration.document.textAnnotationService";
+    }
+}

--- a/generic-rest/src/main/resources/META-INF/components.txt
+++ b/generic-rest/src/main/resources/META-INF/components.txt
@@ -1,3 +1,4 @@
 org.phenotips.textanalysis.internal.GenericRESTAnnotationService
+org.phenotips.textanalysis.internal.RESTWrapperConfigurationSource
 org.phenotips.textanalysis.internal.RESTWrapperImpl
 org.phenotips.textanalysis.internal.AnnotationAPIFactoryImpl

--- a/ui/src/main/resources/PhenoTips/TextAnnotationConfiguration.xml
+++ b/ui/src/main/resources/PhenoTips/TextAnnotationConfiguration.xml
@@ -72,7 +72,7 @@
   #end
   &lt;p&gt;
     &lt;label&gt;
-      &lt;input type="radio" name="${prefix}${name}" value="$url" #if($url == $value)checked="checked" #set($isDefaultService = true)#end/&gt;
+      &lt;input type="radio" name="${prefix}${name}" value="$escapetool.xml($url)" #if($url == $value)checked="checked" #set($isDefaultService = true)#end/&gt;
       $url
     &lt;/label&gt;
     #if ($info != '')
@@ -82,8 +82,8 @@
 #end
 &lt;p&gt;
   &lt;label&gt;
-    &lt;input type="radio" name="${prefix}${name}" #if(!$isDefaultService)value="$value" checked="checked"#else value=""#end onchange="if (this.checked) {this.next('input').focus()}"/&gt;
-    &lt;input type="text" name="${prefix}${name}" placeholder="Other (enter service URL)" value="#if(!$isDefaultService)$!value#end" onfocus="this.previous().checked='checked'" onchange="this.previous().value=this.value" style="width: 90%"/&gt;
+    &lt;input type="radio" name="${prefix}${name}" #if(!$isDefaultService)value="$escapetool.xml($value)" checked="checked"#else value=""#end onchange="if (this.checked) {this.next('input').focus()}"/&gt;
+    &lt;input type="text" name="${prefix}${name}" placeholder="$escapetool.xml($services.localization.render('PhenoTips.TextAnnotationConfiguration_serviceURL_other.placeholder'))" value="#if(!$isDefaultService)$!escapetool.xml($!value)#end" onfocus="this.previous().checked='checked'" onchange="this.previous().value=this.value" style="width: 90%"/&gt;
   &lt;/label&gt;
 &lt;/p&gt;
 {{/html}}</customDisplay>

--- a/ui/src/main/resources/PhenoTips/TextAnnotationConfiguration.xml
+++ b/ui/src/main/resources/PhenoTips/TextAnnotationConfiguration.xml
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+-->
+
+<xwikidoc version="1.1">
+  <web>PhenoTips</web>
+  <name>TextAnnotationConfiguration</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1504889581000</creationDate>
+  <parent>PhenoTips.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1504891315000</date>
+  <contentUpdateDate>1504889659000</contentUpdateDate>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content/>
+  <object>
+    <name>PhenoTips.TextAnnotationConfiguration</name>
+    <number>0</number>
+    <className>PhenoTips.TextAnnotationConfigurationClass</className>
+    <guid>74112c22-e75a-4a2b-aa7f-1a882c9f0227</guid>
+    <class>
+      <name>PhenoTips.TextAnnotationConfigurationClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <serviceURL>
+        <cache>0</cache>
+        <customDisplay>{{velocity}}
+#set ($defaultServices = {
+  'defaultLocalCtakes' : 'http://localhost:8080/ctakes/'
+})
+#if ("$!value" == '')
+  #set ($value = $defaultServices.get('defaultLocalCtakes'))
+#end
+#set ($isDefaultService = false)
+{{html clean="false" wiki="false"}}
+#foreach ($s in $defaultServices.keySet())
+  #set ($url = $defaultServices.get($s))
+  #set ($infoKey = "PhenoTips.TextAnnotationConfiguration_serviceURL_${s}.hint")
+  #set ($info = $escapetool.xml($services.localization.render($infoKey)))
+  #if ($info == $infoKey)
+    #set ($info = '')
+  #end
+  &lt;p&gt;
+    &lt;label&gt;
+      &lt;input type="radio" name="${prefix}${name}" value="$url" #if($url == $value)checked="checked" #set($isDefaultService = true)#end/&gt;
+      $url
+    &lt;/label&gt;
+    #if ($info != '')
+      &lt;span class="xHelpButton fa fa-info-circle" title="${info}"&gt; &lt;/span&gt;
+    #end
+  &lt;/p&gt;
+#end
+&lt;p&gt;
+  &lt;label&gt;
+    &lt;input type="radio" name="${prefix}${name}" #if(!$isDefaultService)value="$value" checked="checked"#else value=""#end onchange="if (this.checked) {this.next('input').focus()}"/&gt;
+    &lt;input type="text" name="${prefix}${name}" placeholder="Other (enter service URL)" value="#if(!$isDefaultService)$!value#end" onfocus="this.previous().checked='checked'" onchange="this.previous().value=this.value" style="width: 90%"/&gt;
+  &lt;/label&gt;
+&lt;/p&gt;
+{{/html}}</customDisplay>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>0</multiSelect>
+        <name>serviceURL</name>
+        <number>2</number>
+        <picker>0</picker>
+        <prettyName>Text mining service URL</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <sort>none</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </serviceURL>
+    </class>
+    <property>
+      <serviceURL>http://localhost:8080/ctakes/</serviceURL>
+    </property>
+  </object>
+  <object>
+    <name>PhenoTips.TextAnnotationConfiguration</name>
+    <number>0</number>
+    <className>XWiki.ConfigurableClass</className>
+    <guid>1f26f2cd-3ea0-43c1-b9a1-7625bd51bf7c</guid>
+    <class>
+      <name>XWiki.ConfigurableClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <advancedOnly>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>advancedOnly</name>
+        <number>5</number>
+        <prettyName>advancedOnly</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </advancedOnly>
+      <categoryPriority>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>categoryPriority</name>
+        <number>2</number>
+        <numberType>integer</numberType>
+        <prettyName>categoryPriority</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </categoryPriority>
+      <codeToExecute>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>---</editor>
+        <name>codeToExecute</name>
+        <number>11</number>
+        <picker>0</picker>
+        <prettyName>codeToExecute</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </codeToExecute>
+      <configurationClass>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>configurationClass</name>
+        <number>7</number>
+        <picker>0</picker>
+        <prettyName>configurationClass</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </configurationClass>
+      <configureGlobally>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayFormType>checkbox</displayFormType>
+        <displayType/>
+        <name>configureGlobally</name>
+        <number>8</number>
+        <prettyName>configureGlobally</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </configureGlobally>
+      <displayInCategory>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>displayInCategory</name>
+        <number>1</number>
+        <picker>0</picker>
+        <prettyName>displayInCategory</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </displayInCategory>
+      <displayInSection>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>displayInSection</name>
+        <number>3</number>
+        <picker>0</picker>
+        <prettyName>displayInSection</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </displayInSection>
+      <heading>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>heading</name>
+        <number>6</number>
+        <picker>0</picker>
+        <prettyName>heading</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </heading>
+      <iconAttachment>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>iconAttachment</name>
+        <number>12</number>
+        <picker>0</picker>
+        <prettyName>iconAttachment</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </iconAttachment>
+      <linkPrefix>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>linkPrefix</name>
+        <number>9</number>
+        <picker>0</picker>
+        <prettyName>linkPrefix</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </linkPrefix>
+      <propertiesToShow>
+        <cache>0</cache>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>propertiesToShow</name>
+        <number>10</number>
+        <picker>0</picker>
+        <prettyName>propertiesToShow</prettyName>
+        <relationalStorage>1</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>20</size>
+        <sort>none</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </propertiesToShow>
+      <sectionPriority>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <name>sectionPriority</name>
+        <number>4</number>
+        <numberType>integer</numberType>
+        <prettyName>sectionPriority</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </sectionPriority>
+    </class>
+    <property>
+      <advancedOnly>1</advancedOnly>
+    </property>
+    <property>
+      <categoryPriority>0</categoryPriority>
+    </property>
+    <property>
+      <codeToExecute/>
+    </property>
+    <property>
+      <configurationClass>PhenoTips.TextAnnotationConfigurationClass</configurationClass>
+    </property>
+    <property>
+      <configureGlobally>1</configureGlobally>
+    </property>
+    <property>
+      <displayInCategory>phenotips</displayInCategory>
+    </property>
+    <property>
+      <displayInSection>textMining</displayInSection>
+    </property>
+    <property>
+      <heading>$services.localization.render('phenotips.textMining.admin.title')</heading>
+    </property>
+    <property>
+      <iconAttachment/>
+    </property>
+    <property>
+      <linkPrefix/>
+    </property>
+    <property>
+      <propertiesToShow>
+        <value>serviceURL</value>
+      </propertiesToShow>
+    </property>
+    <property>
+      <sectionPriority>5000</sectionPriority>
+    </property>
+  </object>
+</xwikidoc>

--- a/ui/src/main/resources/PhenoTips/TextAnnotationConfigurationClass.xml
+++ b/ui/src/main/resources/PhenoTips/TextAnnotationConfigurationClass.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+-->
+
+<xwikidoc version="1.1">
+  <web>PhenoTips</web>
+  <name>TextAnnotationConfigurationClass</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1504871353000</creationDate>
+  <parent>PhenoTips.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1504891291000</date>
+  <contentUpdateDate>1504891159000</contentUpdateDate>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content>admin.textmining=Text mining
+phenotips.textMining.admin.title=Text mining service settings
+PhenoTips.TextAnnotationConfiguration_serviceURL=Text mining service URL
+PhenoTips.TextAnnotationConfiguration_serviceURL_defaultLocalCtakes.hint=This is the default embedded text analyzer. To run the default analyzer at a different port, please use the "Other" option below with the URL "http://localhost:{other_port}/ctakes/".</content>
+  <class>
+    <name>PhenoTips.TextAnnotationConfigurationClass</name>
+    <customClass/>
+    <customMapping/>
+    <defaultViewSheet/>
+    <defaultEditSheet/>
+    <defaultWeb/>
+    <nameField/>
+    <validationScript/>
+    <serviceURL>
+      <cache>0</cache>
+      <customDisplay>{{velocity}}
+#set ($defaultServices = {
+  'defaultLocalCtakes' : 'http://localhost:8080/ctakes/'
+})
+#if ("$!value" == '')
+  #set ($value = $defaultServices.get('defaultLocalCtakes'))
+#end
+#set ($isDefaultService = false)
+{{html clean="false" wiki="false"}}
+#foreach ($s in $defaultServices.keySet())
+  #set ($url = $defaultServices.get($s))
+  #set ($infoKey = "PhenoTips.TextAnnotationConfiguration_serviceURL_${s}.hint")
+  #set ($info = $escapetool.xml($services.localization.render($infoKey)))
+  #if ($info == $infoKey)
+    #set ($info = '')
+  #end
+  &lt;p&gt;
+    &lt;label&gt;
+      &lt;input type="radio" name="${prefix}${name}" value="$url" #if($url == $value)checked="checked" #set($isDefaultService = true)#end/&gt;
+      $url
+    &lt;/label&gt;
+    #if ($info != '')
+      &lt;span class="xHelpButton fa fa-info-circle" title="${info}"&gt; &lt;/span&gt;
+    #end
+  &lt;/p&gt;
+#end
+&lt;p&gt;
+  &lt;label&gt;
+    &lt;input type="radio" name="${prefix}${name}" #if(!$isDefaultService)value="$value" checked="checked"#else value=""#end onchange="if (this.checked) {this.next('input').focus()}"/&gt;
+    &lt;input type="text" name="${prefix}${name}" placeholder="Other (enter service URL)" value="#if(!$isDefaultService)$!value#end" onfocus="this.previous().checked='checked'" onchange="this.previous().value=this.value" style="width: 90%"/&gt;
+  &lt;/label&gt;
+&lt;/p&gt;
+{{/html}}</customDisplay>
+      <disabled>0</disabled>
+      <displayType>input</displayType>
+      <multiSelect>0</multiSelect>
+      <name>serviceURL</name>
+      <number>2</number>
+      <picker>0</picker>
+      <prettyName>Text mining service URL</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators>|, </separators>
+      <size>1</size>
+      <sort>none</sort>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </serviceURL>
+  </class>
+  <object>
+    <name>PhenoTips.TextAnnotationConfigurationClass</name>
+    <number>0</number>
+    <className>XWiki.TranslationDocumentClass</className>
+    <guid>73cb26ef-fa65-466f-bfd3-bf5b1c86e1c2</guid>
+    <class>
+      <name>XWiki.TranslationDocumentClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>1</number>
+        <prettyName>Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <scope>WIKI</scope>
+    </property>
+  </object>
+</xwikidoc>

--- a/ui/src/main/resources/PhenoTips/TextAnnotationConfigurationClass.xml
+++ b/ui/src/main/resources/PhenoTips/TextAnnotationConfigurationClass.xml
@@ -40,7 +40,8 @@
   <content>admin.textmining=Text mining
 phenotips.textMining.admin.title=Text mining service settings
 PhenoTips.TextAnnotationConfiguration_serviceURL=Text mining service URL
-PhenoTips.TextAnnotationConfiguration_serviceURL_defaultLocalCtakes.hint=This is the default embedded text analyzer. To run the default analyzer at a different port, please use the "Other" option below with the URL "http://localhost:{other_port}/ctakes/".</content>
+PhenoTips.TextAnnotationConfiguration_serviceURL_defaultLocalCtakes.hint=This is the default embedded text analyzer. To run the default analyzer at a different port, please use the "Other" option below with the URL "http://localhost:{other_port}/ctakes/".
+PhenoTips.TextAnnotationConfiguration_serviceURL_other.placeholder=Other (enter service URL)</content>
   <class>
     <name>PhenoTips.TextAnnotationConfigurationClass</name>
     <customClass/>
@@ -70,7 +71,7 @@ PhenoTips.TextAnnotationConfiguration_serviceURL_defaultLocalCtakes.hint=This is
   #end
   &lt;p&gt;
     &lt;label&gt;
-      &lt;input type="radio" name="${prefix}${name}" value="$url" #if($url == $value)checked="checked" #set($isDefaultService = true)#end/&gt;
+      &lt;input type="radio" name="${prefix}${name}" value="$escapetool.xml($url)" #if($url == $value)checked="checked" #set($isDefaultService = true)#end/&gt;
       $url
     &lt;/label&gt;
     #if ($info != '')
@@ -80,8 +81,8 @@ PhenoTips.TextAnnotationConfiguration_serviceURL_defaultLocalCtakes.hint=This is
 #end
 &lt;p&gt;
   &lt;label&gt;
-    &lt;input type="radio" name="${prefix}${name}" #if(!$isDefaultService)value="$value" checked="checked"#else value=""#end onchange="if (this.checked) {this.next('input').focus()}"/&gt;
-    &lt;input type="text" name="${prefix}${name}" placeholder="Other (enter service URL)" value="#if(!$isDefaultService)$!value#end" onfocus="this.previous().checked='checked'" onchange="this.previous().value=this.value" style="width: 90%"/&gt;
+    &lt;input type="radio" name="${prefix}${name}" #if(!$isDefaultService)value="$escapetool.xml($value)" checked="checked"#else value=""#end onchange="if (this.checked) {this.next('input').focus()}"/&gt;
+    &lt;input type="text" name="${prefix}${name}" placeholder="$escapetool.xml($services.localization.render('PhenoTips.TextAnnotationConfiguration_serviceURL_other.placeholder'))" value="#if(!$isDefaultService)$!escapetool.xml($!value)#end" onfocus="this.previous().checked='checked'" onchange="this.previous().value=this.value" style="width: 90%"/&gt;
   &lt;/label&gt;
 &lt;/p&gt;
 {{/html}}</customDisplay>


### PR DESCRIPTION
Can be tested on https://ta.phenotips.org/ . These changes simply add the admin section which saves the preferred service URL. The actual URL is not yet taken into account by the text-mining component.

![image](https://user-images.githubusercontent.com/651980/30232153-57b2703c-94bc-11e7-9fcb-b5c01b537733.png)
